### PR TITLE
Update to apply more recent Package.swift structure to support Swift5+ (and Xcode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 .build/
 Squall.xcodeproj
+.swiftpm

--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,12 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(
-    name: "Squall"
+    name: "Squall",
+    products: [
+        .library(name: "Squall", targets: ["Squall"])
+    ],
+    targets: [
+        .target(name: "Squall", path: "Sources")
+    ]
 )


### PR DESCRIPTION
:wave: @quells 

I tried to use this package directly from Xcode 12.4 (Swift5), but got an unusual error:
`because every version of Squall contains incompatible tools version and root depends on Squall 1.3.2, version solving failed.`

Once I updated the package.swift to support a more recent version (I went for `5.0`), I was able to tag it from my fork and use it in my project. Since I did the work, I wanted to offer it back to you - hence the pull request.